### PR TITLE
Constrain operations and relax config defaults

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -16,7 +16,7 @@
         <version.model>0.1.0-SNAPSHOT</version.model>
 
         <version.core.lightblue>1.11.0-SNAPSHOT</version.core.lightblue>
-        <version.mongo.lightblue>1.10.0</version.mongo.lightblue>
+        <version.mongo.lightblue>1.11.0-SNAPSHOT</version.mongo.lightblue>
 
         <version.slf4j>1.7.7</version.slf4j>
 

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
@@ -1,13 +1,11 @@
 package org.esbtools.lightbluenotificationhook;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.redhat.lightblue.DataError;
 import com.redhat.lightblue.EntityVersion;
 import com.redhat.lightblue.Response;
 import com.redhat.lightblue.config.LightblueFactory;
 import com.redhat.lightblue.config.LightblueFactoryAware;
+import com.redhat.lightblue.crud.CRUDOperation;
 import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.eval.Projector;
 import com.redhat.lightblue.hooks.CRUDHook;
@@ -16,46 +14,50 @@ import com.redhat.lightblue.mediator.Mediator;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.Field;
 import com.redhat.lightblue.metadata.HookConfiguration;
+import com.redhat.lightblue.util.DocComparator;
 import com.redhat.lightblue.util.Error;
+import com.redhat.lightblue.util.JsonCompare;
 import com.redhat.lightblue.util.JsonDoc;
 import com.redhat.lightblue.util.JsonNodeCursor;
 import com.redhat.lightblue.util.Path;
-import com.redhat.lightblue.util.JsonCompare;
-import com.redhat.lightblue.util.DocComparator;
-import com.redhat.lightblue.query.Projection;
-import com.redhat.lightblue.query.FieldProjection;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class NotificationHook implements CRUDHook, LightblueFactoryAware {
-
-    private static final Projection ALL_FIELDS=new FieldProjection(new Path("*"),true,true);
-    private static final Projection NO_FIELDS=new FieldProjection(new Path("*"),false,false);
     
     private final String name;
     private final JsonNodeFactory jsonNodeFactory;
     private final ObjectMapper objectMapper;
 
-    private LightblueFactory lightblueFactory;
+    private @Nullable LightblueFactory lightblueFactory;
+    private @Nullable Mediator mediator;
 
     private static final Logger LOGGER=LoggerFactory.getLogger(NotificationHook.class);
 
     public NotificationHook(String name) {
-        this(name, new ObjectMapper(), JsonNodeFactory.withExactBigDecimals(true));
+        this(name, null);
+    }
+
+    public NotificationHook(String name, Mediator mediator) {
+        this(name, new ObjectMapper(), JsonNodeFactory.withExactBigDecimals(true), mediator);
     }
 
     public NotificationHook(String name, ObjectMapper objectMapper,
-            JsonNodeFactory jsonNodeFactory) {
+            JsonNodeFactory jsonNodeFactory, Mediator mediator) {
         this.name = name;
         this.jsonNodeFactory = jsonNodeFactory;
         this.objectMapper = objectMapper;
+        this.mediator = mediator;
     }
 
     @Override
@@ -80,9 +82,9 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
         NotificationHookConfiguration config = (NotificationHookConfiguration) hookConfiguration;
         Mediator mediator = tryGetMediator();
 
-        Projector watchProjector = Projector.getInstance(config.watchProjection()==null?ALL_FIELDS:config.watchProjection(), entityMetadata);
-        Projector includeProjector = Projector.getInstance(config.includeProjection()==null?NO_FIELDS:config.includeProjection(),
-                                                           entityMetadata);
+        Projector watchProjector = Projector.getInstance(config.watchProjection(), entityMetadata);
+        Projector includeProjector = Projector.getInstance(config.includeProjection(), entityMetadata);
+
         for (HookDoc hookDoc : hookDocs) {
             HookResult result = processSingleHookDoc(entityMetadata,
                                                      watchProjector,
@@ -108,8 +110,9 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
         LOGGER.debug("Processing doc starts");
         JsonDoc postDoc = hookDoc.getPostDoc();
         JsonDoc preDoc = hookDoc.getPreDoc();
-        
-        if (postDoc == null) {
+
+        // TODO(ahenning): Support delete
+        if (hookDoc.getCRUDOperation().equals(CRUDOperation.FIND) || postDoc == null) {
             return HookResult.aborted();
         }
 
@@ -214,11 +217,12 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
         }
         
         notificationEntity.setEntityData(data);
-        
+
+        // TODO(ahenning): Support delete
         NotificationEntity.Operation operation = hookDoc.getPreDoc() == null
-            ? NotificationEntity.Operation.INSERT
-            : NotificationEntity.Operation.UPDATE;
-        
+            ? NotificationEntity.Operation.insert
+            : NotificationEntity.Operation.update;
+
         notificationEntity.setEntityName(metadata.getName());
         notificationEntity.setEntityVersion(metadata.getVersion().getValue());
         notificationEntity.setOperation(operation);
@@ -229,11 +233,28 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
         return notificationEntity;
     }
 
+    // TODO(ahenning): This messiness can be removed if we can inject the lightblue factory in
+    // the parser instead of the hook. Then hook can accept mediator in constructor and we only
+    // validate it is non null and that's it.
     protected Mediator tryGetMediator() {
-        try {
-            return lightblueFactory.getMediator();
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to get Mediator from LightblueFactory!", e);
+        if (mediator != null) {
+            return mediator;
+        }
+
+        synchronized (this) {
+            if (mediator != null) {
+                return mediator;
+            }
+
+            if (lightblueFactory == null) {
+                throw new IllegalStateException("No Mediator or LightblueFactory provided!");
+            }
+
+            try {
+                return mediator = lightblueFactory.getMediator();
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to get Mediator from LightblueFactory!", e);
+            }
         }
     }
 

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
@@ -240,6 +240,7 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
     // TODO(ahenning): This messiness can be removed if we can inject the lightblue factory in
     // the parser instead of the hook. Then hook can accept mediator in constructor and we only
     // validate it is non null and that's it.
+    // See: https://github.com/lightblue-platform/lightblue-core/pull/587
     protected Mediator tryGetMediator() {
         if (mediator != null) {
             return mediator;

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
@@ -74,7 +74,9 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
     public void processHook(EntityMetadata entityMetadata,
                             HookConfiguration hookConfiguration,
                             List<HookDoc> hookDocs) {
-        if (!(hookConfiguration instanceof NotificationHookConfiguration)) {
+        if (hookConfiguration == null) {
+            hookConfiguration = NotificationHookConfiguration.watchingEverythingAndIncludingNothing();
+        } else if (!(hookConfiguration instanceof NotificationHookConfiguration)) {
             throw new IllegalArgumentException("Expected instance of " +
                     "NotificationHookConfiguration but got: " + hookConfiguration);
         }

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHook.java
@@ -75,6 +75,8 @@ public class NotificationHook implements CRUDHook, LightblueFactoryAware {
                             HookConfiguration hookConfiguration,
                             List<HookDoc> hookDocs) {
         if (hookConfiguration == null) {
+            LOGGER.warn("No notificationHook configuration provided, assuming you want to watch "
+                    + "all fields and include only IDs.");
             hookConfiguration = NotificationHookConfiguration.watchingEverythingAndIncludingNothing();
         } else if (!(hookConfiguration instanceof NotificationHookConfiguration)) {
             throw new IllegalArgumentException("Expected instance of " +

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
@@ -30,17 +30,23 @@ public class NotificationHookConfiguration implements HookConfiguration {
     private static final Projection NO_FIELDS = new FieldProjection(new Path("*"), false, false);
 
     private static final NotificationHookConfiguration WATCHING_EVERYTHING_INCLUDING_NOTHING
-            = new NotificationHookConfiguration(null, null, false);
+            = new NotificationHookConfiguration(ALL_FIELDS, NO_FIELDS, false);
 
     private final Projection watchProjection;
     private final Projection includeProjection;
     private final boolean arrayOrderingSignificant;
 
-    public NotificationHookConfiguration(Projection watchProjection,
-                                         Projection includeProjection,
+    /**
+     * @param watchProjection If null, defaults to watching all fields.
+     * @param includeProjection If null, defaults to including no fields.
+     * @param arrayOrderingSignificant If an array has the same elements in different order, does
+     * this count as a change?
+     */
+    public NotificationHookConfiguration(@Nullable Projection watchProjection,
+                                         @Nullable Projection includeProjection,
                                          boolean arrayOrderingSignificant) {
-        this.watchProjection = watchProjection;
-        this.includeProjection = includeProjection;
+        this.watchProjection = watchProjection != null ? watchProjection : ALL_FIELDS;
+        this.includeProjection = includeProjection != null ? includeProjection : NO_FIELDS;
         this.arrayOrderingSignificant = arrayOrderingSignificant;
     }
 
@@ -64,11 +70,11 @@ public class NotificationHookConfiguration implements HookConfiguration {
     }
     
     public Projection watchProjection() {
-        return watchProjection != null ? watchProjection : ALL_FIELDS;
+        return watchProjection;
     }
     
     public Projection includeProjection() {
-        return includeProjection != null ? includeProjection : NO_FIELDS;
+        return includeProjection;
     }
 
     public boolean isArrayOrderingSignificant() {
@@ -76,12 +82,9 @@ public class NotificationHookConfiguration implements HookConfiguration {
     }
 
     public <T> void toMetadata(MetadataParser<T> parser, T writeMe) {
-        if(watchProjection!=null)
-            parser.putProjection(writeMe, "watchProjection", watchProjection);
-        if(includeProjection!=null)
-            parser.putProjection(writeMe, "includeProjection", includeProjection);
-        if(arrayOrderingSignificant)
-            parser.putValue(writeMe,"arrayOrderingSignificant",Boolean.TRUE);
+        parser.putProjection(writeMe, "watchProjection", watchProjection);
+        parser.putProjection(writeMe, "includeProjection", includeProjection);
+        parser.putValue(writeMe,"arrayOrderingSignificant",Boolean.TRUE);
     }
 
     @Override

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
@@ -6,6 +6,7 @@ import com.redhat.lightblue.query.FieldProjection;
 import com.redhat.lightblue.query.Projection;
 import com.redhat.lightblue.util.Path;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -28,6 +29,9 @@ public class NotificationHookConfiguration implements HookConfiguration {
     private static final Projection ALL_FIELDS = new FieldProjection(new Path("*"), true, true);
     private static final Projection NO_FIELDS = new FieldProjection(new Path("*"), false, false);
 
+    private static final NotificationHookConfiguration WATCHING_EVERYTHING_INCLUDING_NOTHING
+            = new NotificationHookConfiguration(null, null, false);
+
     private final Projection watchProjection;
     private final Projection includeProjection;
     private final boolean arrayOrderingSignificant;
@@ -41,11 +45,15 @@ public class NotificationHookConfiguration implements HookConfiguration {
     }
 
     public static NotificationHookConfiguration watchingEverythingAndIncludingNothing() {
-        return new NotificationHookConfiguration(null, null, false);
+        return WATCHING_EVERYTHING_INCLUDING_NOTHING;
     }
 
     public static <T> NotificationHookConfiguration fromMetadata(MetadataParser<T> parser,
-                                                                 T parseMe) {
+                                                                 @Nullable T parseMe) {
+        if (parseMe == null) {
+            return watchingEverythingAndIncludingNothing();
+        }
+
         Projection watchProjection = parser.getProjection(parseMe, "watchProjection");
         Projection includeProjection = parser.getProjection(parseMe, "includeProjection");
         Object b=parser.getValueProperty(parseMe, "arrayOrderingSignificant");        

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfiguration.java
@@ -2,7 +2,9 @@ package org.esbtools.lightbluenotificationhook;
 
 import com.redhat.lightblue.metadata.HookConfiguration;
 import com.redhat.lightblue.metadata.parser.MetadataParser;
+import com.redhat.lightblue.query.FieldProjection;
 import com.redhat.lightblue.query.Projection;
+import com.redhat.lightblue.util.Path;
 
 import java.util.Objects;
 
@@ -23,6 +25,9 @@ import java.util.Objects;
  * ignored. Default is false.
  */
 public class NotificationHookConfiguration implements HookConfiguration {
+    private static final Projection ALL_FIELDS = new FieldProjection(new Path("*"), true, true);
+    private static final Projection NO_FIELDS = new FieldProjection(new Path("*"), false, false);
+
     private final Projection watchProjection;
     private final Projection includeProjection;
     private final boolean arrayOrderingSignificant;
@@ -33,6 +38,10 @@ public class NotificationHookConfiguration implements HookConfiguration {
         this.watchProjection = watchProjection;
         this.includeProjection = includeProjection;
         this.arrayOrderingSignificant = arrayOrderingSignificant;
+    }
+
+    public static NotificationHookConfiguration watchingEverythingAndIncludingNothing() {
+        return new NotificationHookConfiguration(null, null, false);
     }
 
     public static <T> NotificationHookConfiguration fromMetadata(MetadataParser<T> parser,
@@ -47,11 +56,11 @@ public class NotificationHookConfiguration implements HookConfiguration {
     }
     
     public Projection watchProjection() {
-        return watchProjection;
+        return watchProjection != null ? watchProjection : ALL_FIELDS;
     }
     
     public Projection includeProjection() {
-        return includeProjection;
+        return includeProjection != null ? includeProjection : NO_FIELDS;
     }
 
     public boolean isArrayOrderingSignificant() {

--- a/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfigurationParser.java
+++ b/lib/src/main/java/org/esbtools/lightbluenotificationhook/NotificationHookConfigurationParser.java
@@ -26,7 +26,9 @@ public class NotificationHookConfigurationParser<T> implements HookConfiguration
 
     @Override
     public void convert(MetadataParser<T> parser, T writeMe, HookConfiguration hookConfiguration) {
-        if (!(hookConfiguration instanceof NotificationHookConfiguration)) {
+        if (hookConfiguration == null) {
+            hookConfiguration = NotificationHookConfiguration.watchingEverythingAndIncludingNothing();
+        } else if (!(hookConfiguration instanceof NotificationHookConfiguration)) {
             throw new IllegalArgumentException("Can only parse NotificationHookConfiguration but " +
                     "got: " + hookConfiguration);
         }

--- a/lib/src/test/java/org/esbtools/lightbluenotificationhook/NotificationHookTest.java
+++ b/lib/src/test/java/org/esbtools/lightbluenotificationhook/NotificationHookTest.java
@@ -1,186 +1,131 @@
 package org.esbtools.lightbluenotificationhook;
 
-import java.util.List;
-import java.util.ArrayList;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-
-import com.redhat.lightblue.*;
-import com.redhat.lightblue.crud.*;
-import com.redhat.lightblue.mediator.*;
-import com.redhat.lightblue.query.*;
-import com.redhat.lightblue.util.*;
-import com.redhat.lightblue.metadata.*;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.crud.CRUDOperation;
+import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.hooks.HookDoc;
+import com.redhat.lightblue.mediator.Mediator;
+import com.redhat.lightblue.metadata.DataStore;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.HookConfiguration;
+import com.redhat.lightblue.metadata.PredefinedFields;
+import com.redhat.lightblue.metadata.TypeResolver;
+import com.redhat.lightblue.metadata.parser.DataStoreParser;
 import com.redhat.lightblue.metadata.parser.Extensions;
 import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
-import com.redhat.lightblue.metadata.parser.DataStoreParser;
 import com.redhat.lightblue.metadata.parser.MetadataParser;
 import com.redhat.lightblue.metadata.types.DefaultTypes;
-
+import com.redhat.lightblue.query.Projection;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonUtils;
+import com.redhat.lightblue.util.Path;
 import com.redhat.lightblue.util.test.AbstractJsonSchemaTest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class NotificationHookTest extends AbstractJsonSchemaTest {
-
-    public class TestNotificationHook extends NotificationHook {
-        public TestNotificationHook(String name) {
-            super(name);
-        }
-
-        protected Mediator tryGetMediator() {
-            return mediator;
-        }
-    }
-
-    public class TestMediator extends Mediator {
-
-        public InsertionRequest req;
-        public Response response=new Response();
+    public static class InsertCapturingMediator extends Mediator {
+        public InsertionRequest capturedInsert;
+        public Response response = new Response();
         
-        public TestMediator() {
+        public InsertCapturingMediator() {
             super(null,null);
         }
 
         public Response insert(InsertionRequest req) {
-            this.req=req;
+            this.capturedInsert = req;
             return response;
         }
     }
 
-    
-    public class TestDataStoreParser<T> implements DataStoreParser<T> {
-        
-        @Override
-        public DataStore parse(String name, MetadataParser<T> p, T node) {
-            return new DataStore() {
-                public String getBackend() {
-                    return "mongo";
-                }
-            };
-        }
-        
-        @Override
-        public void convert(MetadataParser<T> p, T emptyNode, DataStore object) {
-        }
-        
-        @Override
-        public String getDefaultName() {
-            return "mongo";
-        }
-    }
-    
-    private TestNotificationHook hook=new TestNotificationHook("testHook");
-    private TestMediator mediator=new TestMediator();
-
-    private Projection projection(String s) throws Exception {
-        return Projection.fromJson(JsonUtils.json(s.replaceAll("\'","\"")));
-    }
-
-    public EntityMetadata getMd(String fname) throws Exception {
-        JsonNode node = loadJsonNode(fname);
-        Extensions<JsonNode> extensions = new Extensions<>();
-        extensions.addDefaultExtensions();
-        extensions.registerDataStoreParser("mongo", new TestDataStoreParser<JsonNode>());
-        TypeResolver resolver = new DefaultTypes();
-        JSONMetadataParser parser = new JSONMetadataParser(extensions, resolver, JsonNodeFactory.instance);
-        EntityMetadata md = parser.parseEntityMetadata(node);
-        PredefinedFields.ensurePredefinedFields(md);
-        return md;
-    }
+    private InsertCapturingMediator insertCapturingMediator = new InsertCapturingMediator();
+    private NotificationHook hook = new NotificationHook("testHook", insertCapturingMediator);
 
     @Test
-    public void testIns() throws Exception {
-        EntityMetadata md=getMd("usermd.json");
-        JsonNode data=loadJsonNode("userdata.json");
-        // Watch anything under "personalInfo"
-        // Only store id in notification
-        HookConfiguration cfg=new NotificationHookConfiguration(projection("{'field':'personalInfo','recursive':1}"),
-                                                                null,
-                                                                false);
+    public void shouldCreateNotificationWithIdsForEntityInsertsWhichContainWatchedFieldsWhenNoIncludeProjectionConfigured() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+        JsonNode data = loadJsonNode("userdata.json");
+
+        HookConfiguration cfg = new NotificationHookConfiguration(
+                // Watch anything under "personalInfo"
+                projection("{'field':'personalInfo','recursive':1}"),
+                // Only store id in notification
+                null,
+                // Ignore array order
+                false);
 
         // Insertion
-        List<HookDoc> docs=new ArrayList<>();
-        HookDoc doc=new HookDoc(md,null,new JsonDoc(data),CRUDOperation.INSERT,"me");
+        List<HookDoc> docs = new ArrayList<>();
+        HookDoc doc = new HookDoc(md,null,new JsonDoc(data),CRUDOperation.INSERT,"me");
         docs.add(doc);
-        mediator.req=null;
-        hook.processHook(md,cfg,docs);
-        // There must be an insertion request
-        Assert.assertNotNull(mediator.req);
-        // Doc is in the insertion req
-        JsonNode notification=mediator.req.getEntityData();
-        Assert.assertNotNull(notification);
+
+        hook.processHook(md, cfg, docs);
+
+        Assert.assertNotNull("Hook did not insert any notification", insertCapturingMediator.capturedInsert);
+        JsonNode notification = insertCapturingMediator.capturedInsert.getEntityData();
+        Assert.assertNotNull("Hook tried to insert a null notification", notification);
         System.out.println(notification);
-        Assert.assertEquals("user",notification.get("entityName").asText());
-        Assert.assertEquals("5.0.0",notification.get("entityVersion").asText());
-        // The id fields must be there, and nothing else
-        ArrayNode ed=(ArrayNode)notification.get("entityData");
-        Assert.assertEquals(2,ed.size());
-        checkEntityData(ed,"_id","123");
-        checkEntityData(ed,"iduid","345");
+        Assert.assertEquals("user", notification.get("entityName").asText());
+        Assert.assertEquals("5.0.0", notification.get("entityVersion").asText());
+        Assert.assertEquals("insert", notification.get("operation").asText());
+        ArrayNode entityData = (ArrayNode) notification.get("entityData");
+        Assert.assertEquals("Captured more or less entity data than expected", 2, entityData.size());
+        assertEntityDataValueEquals(entityData,"_id","123");
+        assertEntityDataValueEquals(entityData,"iduid","345");
     }
 
     
     @Test
-    public void testUpd() throws Exception {
+    public void shouldCreateNotificationWithIdsForEntityUpdatesWhenWatchedFieldChangesAndNoIncludeProjectionProvided() throws Exception {
         EntityMetadata md=getMd("usermd.json");
         JsonNode pre=loadJsonNode("userdata.json");
         // Watch anything under "personalInfo"
         // Only store id in notification
-        HookConfiguration cfg=new NotificationHookConfiguration(projection("{'field':'personalInfo','recursive':1}"),
-                                                                null,
-                                                                false);
+        HookConfiguration cfg=new NotificationHookConfiguration(
+                projection("{'field':'personalInfo','recursive':1}"),
+                null,
+                false);
 
-        // Update something other than personalinfo
         JsonNode post=loadJsonNode("userdata.json");
-        JsonDoc.modify(post,new Path("login"),JsonNodeFactory.instance.textNode("blah"),true);
-        
-        List<HookDoc> docs=new ArrayList<>();
+        List<HookDoc> docs = new ArrayList<>();
+        JsonDoc.modify(post,new Path("personalInfo.company"),JsonNodeFactory.instance.textNode("blah"),true);
         HookDoc doc=new HookDoc(md,new JsonDoc(pre),new JsonDoc(post),CRUDOperation.UPDATE,"me");
         docs.add(doc);
-        mediator.req=null;
-        hook.processHook(md,cfg,docs);
-        // No request
-        Assert.assertNull(mediator.req);
 
-        // Update something under personalInfo
-        JsonDoc.modify(post,new Path("personalInfo.company"),JsonNodeFactory.instance.textNode("blah"),true);
-        docs=new ArrayList<>();
-        doc=new HookDoc(md,new JsonDoc(pre),new JsonDoc(post),CRUDOperation.UPDATE,"me");
-        docs.add(doc);
-        mediator.req=null;
         hook.processHook(md,cfg,docs);
-        // There must be an insertion request
-        Assert.assertNotNull(mediator.req);
-        // Doc is in the insertion req
-        JsonNode notification=mediator.req.getEntityData();
-        Assert.assertNotNull(notification);
+
+        Assert.assertNotNull("Hook did not insert any notification", insertCapturingMediator.capturedInsert);
+        JsonNode notification= insertCapturingMediator.capturedInsert.getEntityData();
+        Assert.assertNotNull("Hook tried to insert a null notification", notification);
         System.out.println(notification);
         Assert.assertEquals("user",notification.get("entityName").asText());
         Assert.assertEquals("5.0.0",notification.get("entityVersion").asText());
+        Assert.assertEquals("update", notification.get("operation").asText());
         // The id fields must be there, and nothing else
         ArrayNode ed=(ArrayNode)notification.get("entityData");
         Assert.assertEquals(2,ed.size());
-        checkEntityData(ed,"_id","123");
-        checkEntityData(ed,"iduid","345");
+        assertEntityDataValueEquals(ed,"_id","123");
+        assertEntityDataValueEquals(ed,"iduid","345");
     }
 
 
     @Test
-    public void testMoreFields() throws Exception {
+    public void shouldCaptureIncludeProjectionInEntityDataInAdditionToIds() throws Exception {
         EntityMetadata md=getMd("usermd.json");
         JsonNode pre=loadJsonNode("userdata.json");
-        // Watch anything under "personalInfo"
-        // Only store id in notification
-        HookConfiguration cfg=new NotificationHookConfiguration(projection("{'field':'personalInfo','recursive':1}"),
-                                                                projection("[{'field':'login'},{'field':'sites.*.siteType'}]"),
-                                                                false);
+
+        HookConfiguration cfg=new NotificationHookConfiguration(
+                projection("{'field':'personalInfo','recursive':1}"),
+                projection("[{'field':'login'},{'field':'sites.*.siteType'}]"),
+                false);
         
         JsonNode post=loadJsonNode("userdata.json");
         JsonDoc.modify(post,new Path("personalInfo.company"),JsonNodeFactory.instance.textNode("blah"),true);
@@ -188,25 +133,100 @@ public class NotificationHookTest extends AbstractJsonSchemaTest {
         List<HookDoc> docs=new ArrayList<>();
         HookDoc doc=new HookDoc(md,new JsonDoc(pre),new JsonDoc(post),CRUDOperation.UPDATE,"me");
         docs.add(doc);
-        mediator.req=null;
+
         hook.processHook(md,cfg,docs);
 
-        // There must be an insertion request
-        Assert.assertNotNull(mediator.req);
+        Assert.assertNotNull(insertCapturingMediator.capturedInsert);
         // Doc is in the insertion req
-        JsonNode notification=mediator.req.getEntityData();
+        JsonNode notification= insertCapturingMediator.capturedInsert.getEntityData();
         Assert.assertNotNull(notification);
         System.out.println(notification);
         ArrayNode ed=(ArrayNode)notification.get("entityData");
         Assert.assertEquals(5,ed.size());
-        checkEntityData(ed,"_id","123");
-        checkEntityData(ed,"iduid","345");
-        checkEntityData(ed,"login","bserdar");
-        checkEntityData(ed,"sites.0.siteType","shipping");
-        checkEntityData(ed,"sites.1.siteType","billing");
+        assertEntityDataValueEquals(ed,"_id","123");
+        assertEntityDataValueEquals(ed,"iduid","345");
+        assertEntityDataValueEquals(ed,"login","bserdar");
+        assertEntityDataValueEquals(ed,"sites.0.siteType","shipping");
+        assertEntityDataValueEquals(ed,"sites.1.siteType","billing");
     }
 
-    private void checkEntityData(ArrayNode ed,String path,String value) {
+    @Test
+    public void shouldNotCreateNotificationForFindOperations() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+        JsonNode post = loadJsonNode("userdata.json");
+
+        HookConfiguration cfg = NotificationHookConfiguration.watchingEverythingAndIncludingNothing();
+
+        List<HookDoc> docs = new ArrayList<>();
+        // Pre doc is null in find ops: see com.redhat.lightblue.hooks.HookManager:73
+        HookDoc doc = new HookDoc(md,null,new JsonDoc(post),CRUDOperation.FIND,"me");
+        docs.add(doc);
+
+        hook.processHook(md, cfg, docs);
+
+        Assert.assertNull(insertCapturingMediator.capturedInsert);
+    }
+
+    @Test
+    public void shouldNotCreateNotificationIfNothingChangesInWatchedFields() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+        JsonNode pre = loadJsonNode("userdata.json");
+        JsonNode post = loadJsonNode("userdata.json");
+
+        HookConfiguration cfg = NotificationHookConfiguration.watchingEverythingAndIncludingNothing();
+
+        List<HookDoc> docs = new ArrayList<>();
+        HookDoc doc = new HookDoc(md,new JsonDoc(pre),new JsonDoc(post),CRUDOperation.UPDATE,"me");
+        docs.add(doc);
+
+        hook.processHook(md, cfg, docs);
+
+        Assert.assertNull(insertCapturingMediator.capturedInsert);
+    }
+
+    @Test
+    public void shouldNotCreateNotificationsIfSomethingNotWatchedChanged() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+        JsonNode pre = loadJsonNode("userdata.json");
+
+        HookConfiguration cfg = new NotificationHookConfiguration(
+                projection("{'field':'personalInfo','recursive':1}"),
+                null,
+                false);
+
+        JsonNode post = loadJsonNode("userdata.json");
+        JsonDoc.modify(post, new Path("login"), JsonNodeFactory.instance.textNode("blah"), true);
+
+        List<HookDoc> docs= new ArrayList<>();
+        HookDoc doc = new HookDoc(md, new JsonDoc(pre), new JsonDoc(post), CRUDOperation.UPDATE, "me");
+        docs.add(doc);
+
+        hook.processHook(md,cfg,docs);
+
+        Assert.assertNull(insertCapturingMediator.capturedInsert);
+    }
+
+    @Test
+    public void shouldNotCreateNotificationForInsertWhichDoesNotIncludeAnyWatchedFields() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+
+        HookConfiguration cfg = new NotificationHookConfiguration(
+                projection("{'field':'contactPermissions','recursive':1}"),
+                null,
+                false);
+
+        JsonNode post = loadJsonNode("userdataWithoutContactPermissions.json");
+
+        List<HookDoc> docs= new ArrayList<>();
+        HookDoc doc = new HookDoc(md, null, new JsonDoc(post), CRUDOperation.INSERT, "me");
+        docs.add(doc);
+
+        hook.processHook(md,cfg,docs);
+
+        Assert.assertNull(insertCapturingMediator.capturedInsert);
+    }
+
+    private void assertEntityDataValueEquals(ArrayNode ed, String path, String value) {
         int n=ed.size();
         for(int i=0;i<n;i++) {
             ObjectNode node=(ObjectNode)ed.get(i);
@@ -218,5 +238,42 @@ public class NotificationHookTest extends AbstractJsonSchemaTest {
             }
         }
         Assert.fail("Expected to find "+path+":"+value);
+    }
+
+    private Projection projection(String s) throws Exception {
+        return Projection.fromJson(JsonUtils.json(s.replaceAll("\'","\"")));
+    }
+
+    public EntityMetadata getMd(String fname) throws Exception {
+        JsonNode node = loadJsonNode(fname);
+        Extensions<JsonNode> extensions = new Extensions<>();
+        extensions.addDefaultExtensions();
+        extensions.registerDataStoreParser("mongo", new FakeMongoDataStoreParser<JsonNode>());
+        TypeResolver resolver = new DefaultTypes();
+        JSONMetadataParser parser = new JSONMetadataParser(extensions, resolver, JsonNodeFactory.instance);
+        EntityMetadata md = parser.parseEntityMetadata(node);
+        PredefinedFields.ensurePredefinedFields(md);
+        return md;
+    }
+
+    public class FakeMongoDataStoreParser<T> implements DataStoreParser<T> {
+
+        @Override
+        public DataStore parse(String name, MetadataParser<T> p, T node) {
+            return new DataStore() {
+                public String getBackend() {
+                    return "mongo";
+                }
+            };
+        }
+
+        @Override
+        public void convert(MetadataParser<T> p, T emptyNode, DataStore object) {
+        }
+
+        @Override
+        public String getDefaultName() {
+            return "mongo";
+        }
     }
 }

--- a/lib/src/test/java/org/esbtools/lightbluenotificationhook/NotificationHookTest.java
+++ b/lib/src/test/java/org/esbtools/lightbluenotificationhook/NotificationHookTest.java
@@ -226,6 +226,22 @@ public class NotificationHookTest extends AbstractJsonSchemaTest {
         Assert.assertNull(insertCapturingMediator.capturedInsert);
     }
 
+    @Test
+    public void shouldFallBackToWatchingEverythingAndIncludingNothingIfNoConfigurationProvided() throws Exception {
+        EntityMetadata md = getMd("usermd.json");
+        JsonNode pre = loadJsonNode("userdata.json");
+        JsonNode post = loadJsonNode("userdata.json");
+        JsonDoc.modify(post, new Path("login"), JsonNodeFactory.instance.textNode("blah"), true);
+
+        List<HookDoc> docs= new ArrayList<>();
+        HookDoc doc = new HookDoc(md, new JsonDoc(pre), new JsonDoc(post), CRUDOperation.UPDATE, "me");
+        docs.add(doc);
+
+        hook.processHook(md, /* config */ null, docs);
+
+        Assert.assertNotNull(insertCapturingMediator.capturedInsert);
+    }
+
     private void assertEntityDataValueEquals(ArrayNode ed, String path, String value) {
         int n=ed.size();
         for(int i=0;i<n;i++) {

--- a/lib/src/test/resources/userdataWithoutContactPermissions.json
+++ b/lib/src/test/resources/userdataWithoutContactPermissions.json
@@ -1,0 +1,90 @@
+{
+    "objectType":"user",
+    "_id":"123",
+    "iduid":"345",
+    "login":"bserdar",
+    "password":{
+      "hashed":"9F2938406AC8F4B3B081A99464CF4B02E65AFB8E7C721BE87EDF72A95B5EFCB1BF481FC069E328C9AC8D0739ABBF3224F9EB5ACA575A27175C37D125181C5ECE016687BAF3FB431D6CBE1A794282E5430F3DD5210B6773F664DEE684FD112109A0E4249B013576E102A1F5EB3F7D80A12A55C653E3EBE3A40680E092C0260D7F",
+      "salt":"80FED7B01330A517CC3AD6423917605B15515143DD7E6609D4783FF2E2E5247619B35FAEC6AF3944D901816673BEBB27D4DC851A0C3DD8A22BFEBAB5C65ED3D1F3C53497C0A107AB61BAAB918B396A43ED465B550CFC10675E4D712CF6AE3BA873BF31C5CCE1CC0A63BCFFD889C9CBE72DC822AAB9E3A432A45061169412E619"
+      },
+    "active":true,
+    "personalInfo":{
+      "company":"Red Hat",
+      "greeting":"Mr.",
+      "firstName":"Burak",
+      "lastName":"Serdar",
+      "title":"Developer",
+      "email":"bserdar@redhat.com",
+      "emailConfirmed":false,
+      "phoneNumber":"123-1234 2222",
+      "locale":"en_us",
+      "timezone":"America/Denver",
+      "department":"IT"
+      },
+    "sites":[{
+        "siteId":"1",
+        "streetAddress":{
+          "address1":"123 Some street",
+          "city":"Denver",
+          "state":"CO",
+          "country":"US",
+          "countryCode":"US",
+          "postalCode":"80111",
+          "poBox":false,
+          "nonrequid":""
+          },
+        "contactInfo":{
+          "emailAddress":"bserdar@redhat.com",
+          "phoneNumber":"123-1234 2222"
+          },
+        "notes":"Blah blah",
+        "siteType":"shipping",
+        "firstName":"Burak",
+        "lastName":"Serdar",
+        "defaultSite":true,
+        "active":true,
+        "usages":[{
+            "usage":"shipping",
+            "lastUsedOn":"20100425T01:59:57.416-0600"
+            },{
+            "usage":"service",
+            "lastUsedOn":"20121102T16:45:39.429-0600"
+            },{
+            "usage":"marketing",
+            "lastUsedOn":"20130804T10:03:40.621-0600"
+            }]
+        },{
+        "siteId":"2",
+        "streetAddress":{
+          "address1":"123 Some other street",
+          "city":"Chapel Hill",
+          "state":"NC",
+          "country":"US",
+          "countryCode":"US",
+          "postalCode":"27514",
+          "poBox":false,
+          "nonrequid":""
+          },
+        "contactInfo":{
+          "emailAddress":"a@b.com"
+          },
+        "notes":"H9YX0y",
+        "siteType":"billing",
+        "firstName":"someone",
+        "lastName":"lastname",
+        "description":"tSZtyRdu5ge808EJswmuNpw1mmPHPUtX",
+        "defaultSite":false,
+        "active":true,
+        "usages":[{
+            "usage":"service",
+            "lastUsedOn":"20120312T11:27:02.094-0600"
+            },{
+            "usage":"marketing",
+            "lastUsedOn":"20130912T11:52:05.173-0600"
+            }]
+        }
+    ],
+    "createdDate":"20120328T03:19:34.295-0600",
+    "uids":[""],
+    "uid":""
+    }

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.5.3</version>
+            <version>2.7.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/model/src/main/java/org/esbtools/lightbluenotificationhook/NotificationEntity.java
+++ b/model/src/main/java/org/esbtools/lightbluenotificationhook/NotificationEntity.java
@@ -44,7 +44,7 @@ public class NotificationEntity {
     private static final String LIGHTBLUE_DATE_FORMAT = "yyyyMMdd\'T\'HH:mm:ss.SSSZ";
 
     public enum Operation {
-        INSERT, UPDATE
+        insert, update
     }
 
     public String get_id() {


### PR DESCRIPTION
In addition I did some unit test cleanup and some version bumping to get things to build since recent upstream lightblue changes.

Oh, I also snuck in lower-casing the enum values since that, at least internally, is our standard, and we will thus inflict this on the open source community at large ;).

Fixes #5 
Fixes #4